### PR TITLE
chore: refactor track_b to generate embeddings per-story and separate…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ data/
 output/
 __pycache__/
 logs/
+venv/


### PR DESCRIPTION
successfully completes #6 

- separates embedding generation from evaluation logic
- uses the lookup dictionary